### PR TITLE
Update AloTech.php API_URL

### DIFF
--- a/src/AloTech.php
+++ b/src/AloTech.php
@@ -4,7 +4,7 @@ namespace AloTech;
 
 class AloTech
 {
-    const API_URL = 'http://{username}.alo-tech.com/api';
+    const API_URL = 'https://{username}.alo-tech.com/api';
 
     const TYPE_GET = 'GET';
 


### PR DESCRIPTION
Alotech'in son güncellemesinde HTTP adreslerine atılan istekleri HTTPS'e yönlendiriliyor. Dolayısıyla API_URL'in HTTPS olması lazım. Alotech destek ekibi ile görüşüp aşağıdaki yanıtı aldım.


Güvenlik standartları gereği, gelen HTTP istekleri 301 Moved Permanently statü kodu ile HTTPS'e yönlendirilmektedir. Modern ve güncel mimarilerde yapılan HTTP isteklerde HTTPS'e yönlenmesi otomatik olarak gerçekleşmektedir. Fakat eski mimarilerde veya bazı senaryolarda HTTPS redirect takibi bırakılmış olabilir. Bu yüzden bize gelen isteklerde protokolün HTTP yerine HTTPS olarak değiştirilmesi gerekmektedir.

CRM içerisinde yer alan ara butonları arkasında "click2call" fonksiyonu çalışmaktadır, atılan isteğin HTTPS olarak atılması veya mimarinin çevirmeye uygun hale getirilmesini rica ederiz. Güncel olarak function=click2call istekleri tarafımıza gelmemektedir.